### PR TITLE
Stop JIT hot spot counting

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7063,6 +7063,74 @@ exit:
 	return ret;
 }
 
+/* Set counting handler back to original VM handler. */
+static void zend_jit_shutdown_hot_trace_counters(zend_op_array *op_array)
+{
+	zend_jit_op_array_trace_extension *jit_extension;
+	uint32_t i;
+
+	jit_extension = (zend_jit_op_array_trace_extension*)ZEND_FUNC_INFO(op_array);
+	for (i = 0; i < op_array->last; i++) {
+		/* opline with Jitted code handler is ignored. */
+        if (jit_extension->trace_info[i].trace_flags & \
+		(ZEND_JIT_TRACE_JITED|ZEND_JIT_TRACE_BLACKLISTED)) {
+            continue;
+        }
+		zend_shared_alloc_lock();
+        if (jit_extension->trace_info[i].trace_flags & \
+		(ZEND_JIT_TRACE_START_LOOP | ZEND_JIT_TRACE_START_ENTER | ZEND_JIT_TRACE_START_RETURN)) {
+			SHM_UNPROTECT();
+			op_array->opcodes[i].handler = jit_extension->trace_info[i].orig_handler;
+			SHM_PROTECT();
+        }
+		zend_shared_alloc_unlock();
+    }
+}
+
+/* Get the tracing op_array. */
+static void zend_jit_shutdown_persistent_op_array(zend_op_array *op_array) {
+    zend_func_info *func_info = ZEND_FUNC_INFO(op_array);
+    if (!func_info) {
+		return;
+	}
+    if (func_info->flags & ZEND_FUNC_JIT_ON_HOT_TRACE) {
+        zend_jit_shutdown_hot_trace_counters(op_array);
+    }
+}
+
+/* Get all op_arrays with counter handler. */
+static void zend_jit_shutdown_persistent_script(zend_persistent_script *script) {
+	zend_class_entry *ce;
+	zend_op_array *op_array;
+
+	zend_jit_shutdown_persistent_op_array(&script->script.main_op_array);
+
+	ZEND_HASH_FOREACH_PTR(&script->script.function_table, op_array) {
+		zend_jit_shutdown_persistent_op_array(op_array);
+	} ZEND_HASH_FOREACH_END();
+
+	ZEND_HASH_FOREACH_PTR(&script->script.class_table, ce) {
+		ZEND_HASH_FOREACH_PTR(&ce->function_table, op_array) {
+			if (op_array->type == ZEND_USER_FUNCTION) {
+				zend_jit_shutdown_persistent_op_array(op_array);
+			}
+		} ZEND_HASH_FOREACH_END();
+	} ZEND_HASH_FOREACH_END();
+}
+
+/* Get the scripts which are accelerated by JIT */
+static void zend_jit_shutdown_counter_handlers() {
+	for (uint32_t i = 0; i<ZCSG(hash).max_num_entries; i++) {
+		zend_accel_hash_entry *cache_entry;
+		for (cache_entry = ZCSG(hash).hash_table[i]; cache_entry; cache_entry = cache_entry->next) {
+			zend_persistent_script *script;
+			if (cache_entry->indirect) continue;
+			script = (zend_persistent_script *)cache_entry->data;
+			zend_jit_shutdown_persistent_script(script);
+		}
+	}
+}
+
 static void zend_jit_blacklist_root_trace(const zend_op *opline, size_t offset)
 {
 	zend_shared_alloc_lock();
@@ -7443,6 +7511,7 @@ repeat:
 
 	if (ZEND_JIT_TRACE_NUM >= JIT_G(max_root_traces)) {
 		stop = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+        zend_jit_shutdown_counter_handlers();
 		goto abort;
 	}
 
@@ -7744,6 +7813,7 @@ int ZEND_FASTCALL zend_jit_trace_hot_side(zend_execute_data *execute_data, uint3
 
 	if (ZEND_JIT_TRACE_NUM >= JIT_G(max_root_traces)) {
 		stop = ZEND_JIT_TRACE_STOP_TOO_MANY_TRACES;
+		zend_jit_shutdown_counter_handlers();
 		goto abort;
 	}
 


### PR DESCRIPTION
When max_root_trace is reached, JIT in tracing mode will not
compile any new code for root trace and side trace, but
counting hot code is still going. Stop these counting by
replacing counter handler with original handler, which
increases 1.5% performance.

Signed-off-by: Wang, Xue <xue1.wang@intel.com>