### PR TITLE
JIT deepest function firstly

### DIFF
--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -359,6 +359,7 @@ zend_constant* ZEND_FASTCALL zend_jit_check_constant(const zval *key);
 	_(RECURSION_EXIT,    "return from recursive function") \
 	_(BLACK_LIST,        "trace blacklisted") \
 	_(INNER_LOOP,        "inner loop")                     /* trace it */ \
+	_(JIT_DEEPER_FUNC,   "JIT deeper function and skip current trace") /* trace next func */ \
 	_(COMPILED_LOOP,     "compiled loop") \
 	_(TRAMPOLINE,        "trampoline call") \
 	_(BAD_FUNC,          "bad function call") \
@@ -383,8 +384,9 @@ typedef enum _zend_jit_trace_stop {
 #define ZEND_JIT_TRACE_STOP_DONE(ret) \
 	(ret < ZEND_JIT_TRACE_STOP_ERROR)
 
+/* restart to trace a inner loop or deeper function */
 #define ZEND_JIT_TRACE_STOP_REPEAT(ret) \
-	(ret == ZEND_JIT_TRACE_STOP_INNER_LOOP)
+	(ret == ZEND_JIT_TRACE_STOP_INNER_LOOP || ret == ZEND_JIT_TRACE_STOP_JIT_DEEPER_FUNC)
 
 #define ZEND_JIT_TRACE_STOP_MAY_RECOVER(ret) \
 	(ret <= ZEND_JIT_TRACE_STOP_COMPILER_ERROR)

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -1048,6 +1048,13 @@ zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *ex, 
 
 		trace_flags = ZEND_OP_TRACE_INFO(opline, offset)->trace_flags;
 		if (trace_flags) {
+			/* When enter a function, stop current tracing and restart a new one */
+			if (trace_buffer[idx-1].op == ZEND_JIT_TRACE_ENTER) {
+				if (!(trace_flags & ZEND_JIT_TRACE_JITED)) {
+					stop = ZEND_JIT_TRACE_STOP_JIT_DEEPER_FUNC;
+					break;
+				}
+			}
 			if (trace_flags & ZEND_JIT_TRACE_JITED) {
 				if (trace_flags & ZEND_JIT_TRACE_START_LOOP) {
 					if ((start & ZEND_JIT_TRACE_START_LOOP) != 0


### PR DESCRIPTION
Duplicated JITTed code brings overhead for the instruction cache. This patch reduces duplication by JITting deepest inline function first because the same function is JITTed in different root trace or side trace sometimes.
It increases 3% the performance of our workload in tracing mode.